### PR TITLE
Add `withName` method

### DIFF
--- a/etc/caketype.api.md
+++ b/etc/caketype.api.md
@@ -48,6 +48,8 @@ export abstract class Cake<in out T = any> extends Untagged implements CakeRecip
     // (undocumented)
     readonly name: string | null;
     toString(): string;
+    // (undocumented)
+    abstract withName(name: string | null): Cake<T>;
 }
 
 // @public (undocumented)
@@ -314,6 +316,8 @@ export class ObjectCake<P extends ObjectCakeProperties> extends Cake<({
     dispatchStringify(context: CakeDispatchStringifyContext): string;
     // (undocumented)
     readonly properties: Readonly<P>;
+    // (undocumented)
+    withName(name: string | null): ObjectCake<P>;
 }
 
 // @public (undocumented)
@@ -427,6 +431,8 @@ export class ReferenceCake<C extends Cake> extends Cake<Infer<C>> implements Ref
     dispatchStringify(context: CakeDispatchStringifyContext): string;
     // (undocumented)
     readonly get: () => C;
+    // (undocumented)
+    withName(name: string | null): ReferenceCake<C>;
 }
 
 // @public (undocumented)
@@ -470,6 +476,8 @@ export class TypeGuardCake<T> extends Cake<T> implements TypeGuardCakeRecipe<T> 
     dispatchStringify(context: CakeDispatchStringifyContext): string;
     // (undocumented)
     readonly guard: (value: unknown) => value is T;
+    // (undocumented)
+    withName(name: string | null): TypeGuardCake<T>;
 }
 
 // @public (undocumented)

--- a/src/cake/Cake.ts
+++ b/src/cake/Cake.ts
@@ -178,6 +178,8 @@ abstract class Cake<in out T = any> extends Untagged implements CakeRecipe {
    * @public
    */
   abstract dispatchStringify(context: CakeDispatchStringifyContext): string;
+
+  abstract withName(name: string | null): Cake<T>;
 }
 
 /**

--- a/src/cake/ObjectCake.ts
+++ b/src/cake/ObjectCake.ts
@@ -134,6 +134,10 @@ class ObjectCake<P extends ObjectCakeProperties>
       return stringifyPrimitive(key);
     }
   }
+
+  withName(name: string | null): ObjectCake<P> {
+    return new ObjectCake({ ...this, name });
+  }
 }
 
 /**

--- a/src/cake/ReferenceCake.ts
+++ b/src/cake/ReferenceCake.ts
@@ -40,6 +40,10 @@ class ReferenceCake<C extends Cake>
     const { recurse } = context;
     return `reference(() => ${recurse(this.get())})`;
   }
+
+  withName(name: string | null): ReferenceCake<C> {
+    return new ReferenceCake({ ...this, name });
+  }
 }
 
 /**

--- a/src/cake/TypeGuardCake.ts
+++ b/src/cake/TypeGuardCake.ts
@@ -54,6 +54,10 @@ class TypeGuardCake<T> extends Cake<T> implements TypeGuardCakeRecipe<T> {
   ): string {
     return `(type guard ${this.guard.name})`;
   }
+
+  withName(name: string | null): TypeGuardCake<T> {
+    return new TypeGuardCake({ ...this, name });
+  }
 }
 
 /**

--- a/tests/cake/Cake-withName.test.ts
+++ b/tests/cake/Cake-withName.test.ts
@@ -1,0 +1,25 @@
+import {
+  bake,
+  boolean,
+  keysUnsound,
+  reference,
+  TypeGuardCake,
+} from "../../src";
+import { is_boolean } from "../../src/type-guards";
+
+const cakes = {
+  object: bake({}),
+  typeGuard: new TypeGuardCake({ guard: is_boolean }),
+  reference: reference(() => boolean),
+};
+
+test.each(keysUnsound(cakes))("%s.name is null", (cake) => {
+  expect(cakes[cake].name).toStrictEqual(null);
+});
+
+test.each(keysUnsound(cakes))(
+  "%s.withName() returns new Cake with the name",
+  (cake) => {
+    expect(cakes[cake].withName("abcd").name).toStrictEqual("abcd");
+  }
+);


### PR DESCRIPTION
## Description

Add `withName` method which returns a copy of a Cake with the given name.

## Manual Checklist

- [x] Update exports (for public API changes)
- [x] Update API report (for public API changes)