### PR TITLE
Make runtime checks strict by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,29 +124,37 @@ if (result.ok) {
 }
 ```
 
-### Stricter Type-Checking
+### Lenient Type-Checking
 
-By default, runtime type-checking is designed to closely mimic TypeScript's behavior. In particular, objects can contain excess properties that are not declared in their type:
+By default, runtime type-checking is stricter than TypeScript's static type-checking. For example, TypeScript allows objects to contain excess properties that are not declared in their type:
 
 ```ts
 const carol = { name: "Carol", lovesCake: true };
 
 const person: Person = carol;
-// OK, even though lovesCake is not declared in the Person type
-
-Person.as(carol);
-// { name: "Carol", lovesCake: true }
+// TypeScript allows this, even though lovesCake
+// is not declared in the Person type
 ```
 
-To forbid excess properties, use the [asStrict](#cakeasstrict), [isStrict](#cakeisstrict), and [checkStrict](#cakecheckstrict) methods instead:
+However, the strict type-checking used by [Cake.as](#cakeas), [Cake.is](#cakeis), and [Cake.check](#cakecheck) does not allow excess properties:
 
 ```ts
-Person.asStrict(carol);
+Person.as(carol);
 // TypeError: Value does not satisfy type '{name: string, age?: (number) | undefined}': object properties are invalid.
 //   Property "lovesCake": Property is not declared in type and excess properties are not allowed.
 ```
 
-This can be useful for validating parsed JSON values.
+To allow excess properties (and match TypeScript's static type-checking more closely in other ways), use the [asShape](#cakeasshape), [isShape](#cakeisshape), and [checkShape](#cakecheckshape) methods instead:
+
+```ts
+Person.asShape(carol);
+// { name: "Carol", lovesCake: true }
+```
+
+> `caketype` is strict by default, under the assumption that developers should only opt-in to lenient type-checking when necessary. This has two benefits:
+>
+> 1. Runtime type-checking is often used to validate untrusted parsed JSON values from network requests. Strict type-checking is typically more appropriate for this use case.
+> 2. It's easier to find and fix bugs caused by excessively strict type-checking, because values that should be okay will produce visible type errors instead. If the type-checking is too lenient, values that should produce type errors will be considered okay, which could have unexpected effects in other parts of your codebase.
 
 ### Inferring TypeScript Types from Cakes
 
@@ -313,11 +321,11 @@ Numbers.is([2, 3]); // true
 - [Cakes](#cakes)
   - [`Cake`](#cake)
   - [`Cake.as`](#cakeas)
-  - [`Cake.asStrict`](#cakeasstrict)
+  - [`Cake.asShape`](#cakeasshape)
   - [`Cake.check`](#cakecheck)
-  - [`Cake.checkStrict`](#cakecheckstrict)
+  - [`Cake.checkShape`](#cakecheckshape)
   - [`Cake.is`](#cakeis)
-  - [`Cake.isStrict`](#cakeisstrict)
+  - [`Cake.isShape`](#cakeisshape)
   - [`Cake.toString`](#caketostring)
   - [`Infer`](#infer)
 - [Built-in Cakes](#built-in-cakes)
@@ -486,25 +494,29 @@ number.as("oops");
 // TypeError: Value does not satisfy type 'number': type guard failed.
 ```
 
+The default type-checking behavior is stricter than TypeScript, making it
+suitable for validating parsed JSON. For example, excess object properties
+are not allowed.
+
+See [Cake.asShape](#cakeasshape) for more lenient type-checking.
+
 See [Cake.check](#cakecheck) to return the error instead of throwing it.
 
----
+#### `Cake.asShape`
 
-#### `Cake.asStrict`
+Like [Cake.as](#cakeas), but use lenient type-checking at runtime to match
+TypeScript's static type-checking more closely.
 
-Like [Cake.as](#cakeas), but perform additional checks suitable for JSON
-validation.
-
-Excess object properties are allowed by default, but not allowed
-with strict checking:
+Excess object properties are allowed with lenient type-checking,
+but not allowed with strict type-checking:
 
 ```ts
 const Person = bake({ name: string } as const);
 const alice = { name: "Alice", extra: "oops" };
 
-Person.as(alice); // { name: "Alice", extra: "oops" }
+Person.asShape(alice); // { name: "Alice", extra: "oops" }
 
-Person.asStrict(alice);
+Person.as(alice);
 // TypeError: Value does not satisfy type '{name: string}': object properties are invalid.
 //   Property "extra": Property is not declared in type and excess properties are not allowed.
 ```
@@ -556,23 +568,28 @@ number.check(3).errorOr(null); // null
 number.check("oops").errorOr(null); // <CakeError>
 ```
 
+The default type-checking behavior is stricter than TypeScript, making it
+suitable for validating parsed JSON. For example, excess object properties
+are not allowed.
+
+See [Cake.checkShape](#cakecheckshape) for more lenient type-checking.
+
 See [Cake.as](#cakeas) to throw an error if the type is not satisfied.
 
----
+#### `Cake.checkShape`
 
-#### `Cake.checkStrict`
+Like [Cake.check](#cakecheck), but use lenient type-checking at runtime to match
+TypeScript's static type-checking more closely.
 
-Like [Cake.check](#cakecheck), but perform additional checks suitable for JSON
-validation.
-
-Excess object properties are allowed by default, but not allowed
-with strict checking:
+Excess object properties are allowed with lenient type-checking,
+but not allowed with strict type-checking:
 
 ```ts
 const Person = bake({ name: string } as const);
 const alice = { name: "Alice", extra: "oops" };
-Person.check(alice); // Ok(alice)
-Person.checkStrict(alice); // Err(<CakeError>)
+
+Person.checkShape(alice); // Ok(alice)
+Person.check(alice); // Err(<CakeError>)
 ```
 
 ---
@@ -603,21 +620,28 @@ if (number.is(value)) {
 }
 ```
 
+The default type-checking behavior is stricter than TypeScript, making it
+suitable for validating parsed JSON. For example, excess object properties
+are not allowed.
+
+See [Cake.isShape](#cakeisshape) for more lenient type-checking.
+
 ---
 
-#### `Cake.isStrict`
+#### `Cake.isShape`
 
-Like [Cake.is](#cakeis), but perform additional checks suitable for JSON
-validation.
+Like [Cake.is](#cakeis), but use lenient type-checking at runtime to match
+TypeScript's static type-checking more closely.
 
-Excess object properties are allowed by default, but not allowed
-with strict checking:
+Excess object properties are allowed with lenient type-checking,
+but not allowed with strict type-checking:
 
 ```ts
 const Person = bake({ name: string } as const);
 const alice = { name: "Alice", extra: "oops" };
-Person.is(alice); // true
-Person.isStrict(alice); // false
+
+Person.isShape(alice); // true
+Person.is(alice); // false
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -502,6 +502,8 @@ See [Cake.asShape](#cakeasshape) for more lenient type-checking.
 
 See [Cake.check](#cakecheck) to return the error instead of throwing it.
 
+---
+
 #### `Cake.asShape`
 
 Like [Cake.as](#cakeas), but use lenient type-checking at runtime to match
@@ -575,6 +577,8 @@ are not allowed.
 See [Cake.checkShape](#cakecheckshape) for more lenient type-checking.
 
 See [Cake.as](#cakeas) to throw an error if the type is not satisfied.
+
+---
 
 #### `Cake.checkShape`
 

--- a/etc/caketype.api.md
+++ b/etc/caketype.api.md
@@ -54,18 +54,18 @@ export const boolean: TypeGuardCake<boolean>;
 export abstract class Cake<in out T = any> extends Untagged implements CakeRecipe {
     constructor(recipe: CakeRecipe);
     as(value: unknown): T;
-    asStrict(value: unknown): T;
+    asShape(value: unknown): T;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "Result" has more than one declaration; you need to add a TSDoc member reference selector
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "Result" has more than one declaration; you need to add a TSDoc member reference selector
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "Result" has more than one declaration; you need to add a TSDoc member reference selector
     check(value: unknown): Result<T, CakeError>;
-    checkStrict(value: unknown): Result<T, CakeError>;
+    checkShape(value: unknown): Result<T, CakeError>;
     // (undocumented)
     abstract dispatchCheck(value: unknown, context: CakeDispatchCheckContext): CakeError | null;
     // (undocumented)
     abstract dispatchStringify(context: CakeDispatchStringifyContext): string;
     is(value: unknown): value is T;
-    isStrict(value: unknown): boolean;
+    isShape(value: unknown): value is T;
     // (undocumented)
     readonly name: string | null;
     // Warning: (ae-forgotten-export) The symbol "CheckOptions" needs to be exported by the entry point index.d.ts

--- a/src/cake/Cake.ts
+++ b/src/cake/Cake.ts
@@ -73,7 +73,11 @@ abstract class Cake<in out T = any> extends Untagged implements CakeRecipe {
    * // TypeError: Value does not satisfy type 'number': type guard failed.
    * ```
    *
-   * @see {@link Cake.asStrict} for stricter type-checking.
+   * The default type-checking behavior is stricter than TypeScript, making it
+   * suitable for validating parsed JSON. For example, excess object properties
+   * are not allowed.
+   *
+   * @see {@link Cake.asShape} for more lenient type-checking.
    * @see {@link Cake.check} to return the error instead of throwing it.
    */
   as(value: unknown): T {
@@ -85,25 +89,25 @@ abstract class Cake<in out T = any> extends Untagged implements CakeRecipe {
   }
 
   /**
-   * Like {@link Cake.as}, but perform additional checks suitable for JSON
-   * validation.
+   * Like {@link Cake.as}, but use lenient type-checking at runtime to match
+   * TypeScript's static type-checking more closely.
    *
-   * @example Excess object properties are allowed by default, but not allowed
-   * with strict checking:
+   * @example Excess object properties are allowed with lenient type-checking,
+   * but not allowed with strict type-checking:
    *
    * ```ts
    * const Person = bake({ name: string } as const);
    * const alice = { name: "Alice", extra: "oops" };
    *
-   * Person.as(alice); // { name: "Alice", extra: "oops" }
+   * Person.asShape(alice); // { name: "Alice", extra: "oops" }
    *
-   * Person.asStrict(alice);
+   * Person.as(alice);
    * // TypeError: Value does not satisfy type '{name: string}': object properties are invalid.
    * //   Property "extra": Property is not declared in type and excess properties are not allowed.
    * ```
    */
-  asStrict(value: unknown): T {
-    const result = this.checkStrict(value);
+  asShape(value: unknown): T {
+    const result = this.checkShape(value);
     if (result.ok) {
       return result.value;
     }
@@ -150,29 +154,34 @@ abstract class Cake<in out T = any> extends Untagged implements CakeRecipe {
    * number.check("oops").errorOr(null); // <CakeError>
    * ```
    *
-   * @see {@link Cake.checkStrict} for stricter type-checking.
+   * The default type-checking behavior is stricter than TypeScript, making it
+   * suitable for validating parsed JSON. For example, excess object properties
+   * are not allowed.
+   *
+   * @see {@link Cake.checkShape} for more lenient type-checking.
    * @see {@link Cake.as} to throw an error if the type is not satisfied.
    */
   check(value: unknown): Result<T, CakeError> {
-    return new Checker().check(this, value);
+    return new Checker(CheckOptions.STRICT).check(this, value);
   }
 
   /**
-   * Like {@link Cake.check}, but perform additional checks suitable for JSON
-   * validation.
+   * Like {@link Cake.check}, but use lenient type-checking at runtime to match
+   * TypeScript's static type-checking more closely.
    *
-   * @example Excess object properties are allowed by default, but not allowed
-   * with strict checking:
+   * @example Excess object properties are allowed with lenient type-checking,
+   * but not allowed with strict type-checking:
    *
    * ```ts
    * const Person = bake({ name: string } as const);
    * const alice = { name: "Alice", extra: "oops" };
-   * Person.check(alice); // Ok(alice)
-   * Person.checkStrict(alice); // Err(<CakeError>)
+   *
+   * Person.checkShape(alice); // Ok(alice)
+   * Person.check(alice); // Err(<CakeError>)
    * ```
    */
-  checkStrict(value: unknown): Result<T, CakeError> {
-    return new Checker(CheckOptions.STRICT).check(this, value);
+  checkShape(value: unknown): Result<T, CakeError> {
+    return new Checker().check(this, value);
   }
 
   /**
@@ -196,28 +205,33 @@ abstract class Cake<in out T = any> extends Untagged implements CakeRecipe {
    * }
    * ```
    *
-   * @see {@link Cake.isStrict} for stricter type-checking.
+   * The default type-checking behavior is stricter than TypeScript, making it
+   * suitable for validating parsed JSON. For example, excess object properties
+   * are not allowed.
+   *
+   * @see {@link Cake.isShape} for more lenient type-checking.
    */
   is(value: unknown): value is T {
     return this.check(value).ok;
   }
 
   /**
-   * Like {@link Cake.is}, but perform additional checks suitable for JSON
-   * validation.
+   * Like {@link Cake.is}, but use lenient type-checking at runtime to match
+   * TypeScript's static type-checking more closely.
    *
-   * @example Excess object properties are allowed by default, but not allowed
-   * with strict checking:
+   * @example Excess object properties are allowed with lenient type-checking,
+   * but not allowed with strict type-checking:
    *
    * ```ts
    * const Person = bake({ name: string } as const);
    * const alice = { name: "Alice", extra: "oops" };
-   * Person.is(alice); // true
-   * Person.isStrict(alice); // false
+   *
+   * Person.isShape(alice); // true
+   * Person.is(alice); // false
    * ```
    */
-  isStrict(value: unknown): boolean {
-    return this.checkStrict(value).ok;
+  isShape(value: unknown): value is T {
+    return this.checkShape(value).ok;
   }
 
   /**
@@ -244,17 +258,11 @@ abstract class Cake<in out T = any> extends Untagged implements CakeRecipe {
     return new CakeStringifier().stringify(this);
   }
 
-  /**
-   * @public
-   */
   abstract dispatchCheck(
     value: unknown,
     context: CakeDispatchCheckContext
   ): CakeError | null;
 
-  /**
-   * @public
-   */
   abstract dispatchStringify(context: CakeDispatchStringifyContext): string;
 
   abstract withName(name: string | null): Cake<T>;

--- a/src/cake/Cake.ts
+++ b/src/cake/Cake.ts
@@ -162,7 +162,7 @@ abstract class Cake<in out T = any> extends Untagged implements CakeRecipe {
    * @see {@link Cake.as} to throw an error if the type is not satisfied.
    */
   check(value: unknown): Result<T, CakeError> {
-    return new Checker(CheckOptions.STRICT).check(this, value);
+    return new Checker().check(this, value);
   }
 
   /**
@@ -181,7 +181,7 @@ abstract class Cake<in out T = any> extends Untagged implements CakeRecipe {
    * ```
    */
   checkShape(value: unknown): Result<T, CakeError> {
-    return new Checker().check(this, value);
+    return new Checker(CheckOptions.LENIENT).check(this, value);
   }
 
   /**

--- a/src/cake/CheckOptions.ts
+++ b/src/cake/CheckOptions.ts
@@ -4,12 +4,12 @@ interface CheckOptions {
 
 const CheckOptions: {
   STRICT: CheckOptions;
-  DEFAULT: CheckOptions;
+  LENIENT: CheckOptions;
 } = {
   STRICT: {
     objectExcessProperties: "error",
   },
-  DEFAULT: {
+  LENIENT: {
     objectExcessProperties: "ignore",
   },
 };

--- a/src/cake/Checker.ts
+++ b/src/cake/Checker.ts
@@ -27,7 +27,7 @@ class Checker {
   protected readonly context: CakeDispatchCheckContext;
 
   constructor(options?: CheckOptions) {
-    this.options = merge(CheckOptions.DEFAULT, options || {});
+    this.options = merge(CheckOptions.STRICT, options || {});
     this.cache = new Map();
     this.context = {
       recurse: (cake, value) => this.checkVisit(cake, value),

--- a/tests/cake/Cake.test.ts
+++ b/tests/cake/Cake.test.ts
@@ -23,23 +23,28 @@ describe("documentation examples", () => {
     );
   });
 
-  test("asStrict", () => {
+  test("asShape", () => {
     const Person = bake({ name: string } as const);
     const alice = { name: "Alice", extra: "oops" };
 
-    expect(Person.as(alice)).toStrictEqual({ name: "Alice", extra: "oops" });
+    expect(Person.asShape(alice)).toStrictEqual({
+      name: "Alice",
+      extra: "oops",
+    });
 
     expectTypeError(
-      () => Person.asStrict(alice),
+      () => Person.as(alice),
       [
         `Value does not satisfy type '{name: string}': object properties are invalid.`,
         `  Property "extra": Property is not declared in type and excess properties are not allowed.`,
       ].join("\n")
     );
 
-    // Extra test for the successful case:
-    const bob = { name: "Bob" };
-    expect(Person.asStrict(bob)).toStrictEqual(bob);
+    // Extra test for the failing case:
+    expectTypeError(
+      () => Person.asShape("oops"),
+      `Value does not satisfy type '{name: string}': value is not an object.`
+    );
   });
 
   test("check", () => {
@@ -61,19 +66,6 @@ describe("documentation examples", () => {
     );
   });
 
-  test("checkStrict", () => {
-    const Person = bake({ name: string } as const);
-    const alice = { name: "Alice", extra: "oops" };
-    expect(Person.check(alice)).toStrictEqual(Result.ok(alice));
-    expect(Person.checkStrict(alice)).toStrictEqual(
-      Result.err(
-        new ObjectPropertiesCakeError(Person, alice, {
-          extra: new ExcessPropertyPresentCakeError("oops"),
-        })
-      )
-    );
-  });
-
   test("check and Result.valueOr", () => {
     expect(number.check(3).valueOr(0)).toStrictEqual(3);
     expect(number.check("oops").valueOr(0)).toStrictEqual(0);
@@ -82,6 +74,19 @@ describe("documentation examples", () => {
   test("check and Result.errorOr", () => {
     expect(number.check(3).errorOr(null)).toStrictEqual(null);
     expect(number.check("oops").errorOr(null)).toBeInstanceOf(CakeError);
+  });
+
+  test("checkShape", () => {
+    const Person = bake({ name: string } as const);
+    const alice = { name: "Alice", extra: "oops" };
+    expect(Person.checkShape(alice)).toStrictEqual(Result.ok(alice));
+    expect(Person.check(alice)).toStrictEqual(
+      Result.err(
+        new ObjectPropertiesCakeError(Person, alice, {
+          extra: new ExcessPropertyPresentCakeError("oops"),
+        })
+      )
+    );
   });
 
   test("is returns boolean", () => {
@@ -99,11 +104,12 @@ describe("documentation examples", () => {
     })
   );
 
-  test("isStrict", () => {
+  test("isShape", () => {
     const Person = bake({ name: string } as const);
     const alice = { name: "Alice", extra: "oops" };
-    expect(Person.is(alice)).toStrictEqual(true);
-    expect(Person.isStrict(alice)).toStrictEqual(false);
+
+    expect(Person.isShape(alice)).toStrictEqual(true);
+    expect(Person.is(alice)).toStrictEqual(false);
   });
 
   test("toString", () => {

--- a/tests/cake/CakeError.test.ts
+++ b/tests/cake/CakeError.test.ts
@@ -3,7 +3,7 @@ import { expectTypeError } from "../test-helpers";
 
 describe("documentation examples", () => {
   const cake = bake({ name: string } as const);
-  const error = cake.check({}).errorOr(null);
+  const error = cake.checkShape({}).errorOr(null);
   if (error === null) {
     fail();
   }

--- a/tests/cake/CakeError.test.ts
+++ b/tests/cake/CakeError.test.ts
@@ -3,7 +3,7 @@ import { expectTypeError } from "../test-helpers";
 
 describe("documentation examples", () => {
   const cake = bake({ name: string } as const);
-  const error = cake.checkShape({}).errorOr(null);
+  const error = cake.check({}).errorOr(null);
   if (error === null) {
     fail();
   }

--- a/tests/cake/ObjectCake.test.ts
+++ b/tests/cake/ObjectCake.test.ts
@@ -17,7 +17,9 @@ import {
   Cake,
   entriesUnsound,
   boolean,
+  bake,
 } from "../../src";
+import { ExcessPropertyPresentCakeError } from "../../src/cake/ObjectCake";
 
 interface CircularName {
   name?: CircularName | undefined;
@@ -153,8 +155,13 @@ const values: {
   },
   empty: {
     empty: [{}, () => null],
-    function: [() => undefined, () => null],
-    circularNameObj: [circularNameObj, () => null],
+    circularNameObj: [
+      circularNameObj,
+      (c, o) =>
+        new ObjectPropertiesCakeError(c, o as object, {
+          name: new ExcessPropertyPresentCakeError(o),
+        }),
+    ],
   },
   circularName: {
     circularNameObj: [
@@ -217,4 +224,8 @@ test("toString with weird keys", () => {
   expect(cake.toString()).toStrictEqual(
     `{"with space": number, [Symbol(sym)]: boolean, [Symbol(Symbol.iterator)]: string}`
   );
+});
+
+test("function satisfies empty shape", () => {
+  expect(bake({}).isShape(() => null)).toStrictEqual(true);
 });

--- a/tests/readme/getting-started.test.ts
+++ b/tests/readme/getting-started.test.ts
@@ -91,15 +91,18 @@ test("Getting Started", () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const person: Person = carol;
 
-    expect(Person.as(carol)).toStrictEqual({ name: "Carol", lovesCake: true });
-
     expectTypeError(
-      () => Person.asStrict(carol),
+      () => Person.as(carol),
       [
         `Value does not satisfy type '{name: string, age?: (number) | undefined}': object properties are invalid.`,
         `  Property "lovesCake": Property is not declared in type and excess properties are not allowed.`,
       ].join("\n")
     );
+
+    expect(Person.asShape(carol)).toStrictEqual({
+      name: "Carol",
+      lovesCake: true,
+    });
   }
 
   {


### PR DESCRIPTION
## Description

Rename `as` to `asShape` and `asStrict` to `as`, and similarly for `is` and `check`.

## Manual Checklist

- [x] Update exports (for public API changes)
- [x] Update API report (for public API changes)
- [x] Update API Reference to match TSDoc (for TSDoc changes)
- [x] Update API Reference table of contents (if adding, removing, or reordering API items)
- [x] Update unit tests to match TSDoc code examples (for code example changes)
